### PR TITLE
Fixes for inherited HTML attributes

### DIFF
--- a/burda_infinite.theme
+++ b/burda_infinite.theme
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Url;
+use Drupal\Core\Template\Attribute;
 use Drupal\user\Entity\User;
 use Drupal\node\Entity\Node;
 use Drupal\image\Entity\ImageStyle;
@@ -91,5 +92,11 @@ function burda_infinite_preprocess_node(&$variables) {
     $variables['node_seo_title'] = str_replace('"', '', $field_seo_title);
     // Clean up classes array - all classes will be added in
     $variables['attributes']['class'] = array();
+
+    // Instantiate 'wrapper_attributes' attribute object to avoid collisions
+    // with actual node attributes.
+    if ($variables['view_mode'] === 'full') {
+      $variables['wrapper_attributes'] = new Attribute();
+    }
   }
 }

--- a/templates/node/node--article--full.html.twig
+++ b/templates/node/node--article--full.html.twig
@@ -76,20 +76,20 @@
 %}
 
 {# Add data attributes #}
-{% set attributes = attributes.setAttribute('data-view-type', 'infiniteBlockView') %}
-{% set attributes = attributes.setAttribute('data-history-url', path) %}
-{% set attributes = attributes.setAttribute('data-history-title', node_seo_title) %}
-{% set attributes = attributes.setAttribute('data-adsc-adunit1', adsc_adunit1) %}
-{% set attributes = attributes.setAttribute('data-adsc-adunit2', adsc_adunit2) %}
-{% set attributes = attributes.setAttribute('data-adsc-adunit3', adsc_adunit3) %}
-{% set attributes = attributes.setAttribute('data-adsc-keyword', adsc_keyword) %}
-{% set attributes = attributes.setAttribute('data-nid', nid) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-view-type', 'infiniteBlockView') %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-history-url', path) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-history-title', node_seo_title) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit1', adsc_adunit1) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit2', adsc_adunit2) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit3', adsc_adunit3) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-keyword', adsc_keyword) %}
+{% set wrapper_attributes = wrapper_attributes.setAttribute('data-nid', nid) %}
 {# Add data attribute data-no-track only for view mode full #}
 {% if view_mode == 'full' %}
-  {% set attributes = attributes.setAttribute('data-no-track', 'true') %}
+  {% set wrapper_attributes = wrapper_attributes.setAttribute('data-no-track', 'true') %}
 {% endif %}
 
-<div{{ attributes.addClass(wrapper_classes) }}  >
+<div{{ wrapper_attributes.addClass(wrapper_classes) }}  >
   {% block article_header_blocks %}
     {{ content.field_header_blocks }}
   {% endblock %}

--- a/templates/node/node--article--full.html.twig
+++ b/templates/node/node--article--full.html.twig
@@ -79,11 +79,20 @@
 {% set wrapper_attributes = wrapper_attributes.setAttribute('data-view-type', 'infiniteBlockView') %}
 {% set wrapper_attributes = wrapper_attributes.setAttribute('data-history-url', path) %}
 {% set wrapper_attributes = wrapper_attributes.setAttribute('data-history-title', node_seo_title) %}
-{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit1', adsc_adunit1) %}
-{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit2', adsc_adunit2) %}
-{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit3', adsc_adunit3) %}
-{% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-keyword', adsc_keyword) %}
+{% if adsc_adunit1 is not empty %}
+  {% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit1', adsc_adunit1) %}
+{% endif %}
+{% if adsc_adunit2 is not empty %}
+  {% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit2', adsc_adunit2) %}
+{% endif %}
+{% if adsc_adunit3 is not empty %}
+  {% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-adunit3', adsc_adunit3) %}
+{% endif %}
+{% if adsc_keyword is not empty %}
+  {% set wrapper_attributes = wrapper_attributes.setAttribute('data-adsc-keyword', adsc_keyword) %}
+{% endif %}
 {% set wrapper_attributes = wrapper_attributes.setAttribute('data-nid', nid) %}
+
 {# Add data attribute data-no-track only for view mode full #}
 {% if view_mode == 'full' %}
   {% set wrapper_attributes = wrapper_attributes.setAttribute('data-no-track', 'true') %}


### PR DESCRIPTION
This fixes node wrapper attributes being inherited in the actual node display and filters data attributes to only those having values
