### PR TITLE
Fix annoying PHP error when not Facebook app ID is set

### DIFF
--- a/infinite.theme
+++ b/infinite.theme
@@ -54,7 +54,9 @@ function infinite_preprocess_html(&$variables) {
       $metatags = array_merge($metatags, $metatag_manager->tagsFromEntity($entity));
     }
 
-    $variables['fb_vars'] = ['fb_app_id' => $metatags['fb_app_id']];
+    if (isset($metatags['fb_app_id'])) {
+      $variables['fb_vars'] = ['fb_app_id' => $metatags['fb_app_id']];
+    }
     $variables['gtm_vars'] = ['gtm_id' => theme_get_setting('gtm_id')];
   }
 }


### PR DESCRIPTION
@Nicozilla, @dbosen Can you please merge this change, as the error is really annoying and visible on every page
