### PR TITLE
Remove unnsessary role="navigation" and double ID

### DIFF
--- a/templates/blocks/block--system-menu-block.html.twig
+++ b/templates/blocks/block--system-menu-block.html.twig
@@ -40,8 +40,7 @@
  * @ingroup themeable
  */
 #}
-{% set heading_id = attributes.id|clean_id %}
-<nav role="navigation" id="{{ heading_id }}" {{ attributes }}>
+<nav{{ attributes }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {{ title_prefix }}
   {% if configuration.label_display %}


### PR DESCRIPTION
source html had double declaration for ID. Cleaning it.
w3c validator gives no errors any more.
