### PR TITLE
Fixed folder name

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,6 +1,6 @@
 @import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "bootstrap_customisations/variables";
-@import "../bower_components/ionicons/scss/ionicons-variables";
+@import "../bower_components/Ionicons/scss/ionicons-variables";
 
 $content-max-width: 1128px !default;
 


### PR DESCRIPTION
It was have a bad folder name for OS which is strict for folder names.
```
[15:16:49] Starting 'sass'...

events.js:161
      throw er; // Unhandled 'error' event
      ^
Error: ../../contrib/infinite_theme/sass/_variables.scss
Error: File to import not found or unreadable: ../bower_components/ionicons/scss/ionicons-variables
       Parent style sheet: /home/jenkins/workspace/thunder-dev2beta/builds/82/docroot/themes/contrib/infinite_theme/sass/_variables.scss
        on line 3 of ../../contrib/infinite_theme/sass/_variables.scss
>> @import "../bower_components/ionicons/scss/ionicons-variables";
   ^

    at options.error (/home/jenkins/workspace/thunder-dev2beta/builds/82/docroot/themes/custom/marianne/node_modules/node-sass/lib/index.js:286:26)
```

---
Unrelated:
Weird is that installation via my composer (https://github.com/BurdaMagazinOrg/thunder-project/pull/8#issuecomment-281629156) hook not exit as 1 (error) but skip it and go to the end => my build ending with success :-( Any suggestion?
