### PR TITLE
INREL-3304: Removed hard-coded image style for look

### DIFF
--- a/infinite.theme
+++ b/infinite.theme
@@ -247,10 +247,6 @@ function infinite_preprocess_advertising_product(&$variables) {
 
   $variables['data_attributes'] = $data_attributes;
 
-  // change image style for look
-  if ('look' === $variables['elements']['#view_mode']) {
-    $variables['content']['product_image'][0]['#build']['settings']['image_style'] = 'shop_the_look_product';
-  }
 }
 
 /**


### PR DESCRIPTION
It is not a good solution to hard-code image styles inside a preprocess hook. Besides it leads to unforseen behaviours with blazy module.