### PR TITLE
INREL-3236: Search

### DIFF
--- a/js/infinite/models/modal-search-model.js
+++ b/js/infinite/models/modal-search-model.js
@@ -8,6 +8,7 @@
     },
     ajaxModel: null,
     url: AppConfig.searchApiUrl,
+    isUserSearching: false,
     initialize: function (pOptions) {
       BaseCollectionModel.prototype.initialize.call(this, pOptions);
     },


### PR DESCRIPTION
## [INREL-3552](https://jira.burda.com/browse/INREL-3552) 
This PR changes the color of the search modal when the user interacts with the search bar.
It is part of the Rebrush INREL-3236 epic and thus should only be merged to `feature/INREL-3236`.

Expected behavior: 
- Search user interaction > background pink
- Search finished or no more interaction > background white

## How to test:
Please review mainly the JS.

Before: Check out current behavior on instyle.de

1. Check out

- This branch and
- on custom: feature/INREL-3236 (https://github.com/BurdaMagazinOrg/instyle-web/pull/242). That branch contains CSS.

2. Click on the search bar on the right. It should change color when user interacts:

![searchbar](https://user-images.githubusercontent.com/1830601/36990418-f6b138a2-20a4-11e8-9a83-1e717dee21ed.gif)



## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
