### PR TITLE
INREL-3757: replace spotlight h2 div

### DIFF
--- a/templates/paragraphs/paragraph--spotlight.html.twig
+++ b/templates/paragraphs/paragraph--spotlight.html.twig
@@ -55,21 +55,16 @@
         </div>
         {% block spotlight_caption_block %}
             <div class="caption spotlight__caption">
-                {% if has_headline %}
-                    <div class="title spotlight__title">
+                <div class="title spotlight__title">
+                    {% if has_headline %}
                         <h1>{{ content.field_title | plain_text }}</h1>
-                    </div>
-                    <div class="subtitle spotlight__subtitle">
-                        <h2>{{ content.field_subtitle }}</h2>
-                    </div>
-                {% else %}
-                    <div class="title spotlight__title">
+                    {% else %}
                         <h2>{{ content.field_title | plain_text }}</h2>
-                    </div>
-                    <div class="subtitle spotlight__subtitle">
-                        <h3>{{ content.field_subtitle }}</h3>
-                    </div>
-                {% endif %}
+                    {% endif %}
+                </div>
+                <div class="subtitle spotlight__subtitle">
+                    <div>{{ content.field_subtitle }}</div>
+                </div>
                 <div class="copytext spotlight__copytext">
                     {{ content.field_text }}
                 </div>

--- a/templates/paragraphs/paragraph--spotlight.html.twig
+++ b/templates/paragraphs/paragraph--spotlight.html.twig
@@ -56,6 +56,7 @@
         {% block spotlight_caption_block %}
             <div class="caption spotlight__caption">
                 <div class="title spotlight__title">
+                    <!-- if spotlight has_headline -->
                     {% if has_headline %}
                         <h1>{{ content.field_title | plain_text }}</h1>
                     {% else %}


### PR DESCRIPTION
## [INREL-3757](https://jira.burda.com/browse/INREL-3757) 
Spotlight subheading (h2/h3) has been replaced with div

## How to test:
Related PRs:
 - [freundin-web:#169](https://github.com/BurdaMagazinOrg/freundin-web/pull/169)
 - [bazaar-web:#123](https://github.com/BurdaMagazinOrg/bazaar-web/pull/123)
 - [elle-web:#148](https://github.com/BurdaMagazinOrg/elle-web/pull/148)
 - [instyle-web:#353](https://github.com/BurdaMagazinOrg/instyle-web/pull/353)

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
