### PR TITLE
INREL-4150: resolved issue with alignment for teasers

### DIFF
--- a/sass/mixins/_mixins.paragraphs.scss
+++ b/sass/mixins/_mixins.paragraphs.scss
@@ -450,6 +450,16 @@
 
   .list__content-teaser--horizontal {
     @extend %list__content-teaser--horizontal;
+
+    .teaser-wrapper {
+      flex-basis: 33.3%;
+      max-width: 33.3%;
+
+      .teaser {
+        float: none;
+        width: initial;
+      }
+    }
   }
 
   .teaser {


### PR DESCRIPTION
## [INREL-4150](https://jira.burda.com/browse/INREL-4150) 
 - Recent content teasers were stacked vertically 
 - Recent content teasers are once again displayed in a grid
 - [bazaar-PR#131](https://github.com/BurdaMagazinOrg/bazaar-web/pull/131)

## How to test:
 - add recent content paragraph

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
