### PR TITLE
INREL-4135 ecommerce slider lazyloading

### DIFF
--- a/infinite.libraries.yml
+++ b/infinite.libraries.yml
@@ -17,12 +17,12 @@ blockadblock:
 
 swiper:
   remote: https://github.com/nolimits4web/Swiper
-  version: 3.4.2
+  version: 4.3.3
   license:
     name: MIT
     gpl-compatible: true
   js:
-    /libraries/swiper/dist/js/swiper.jquery.min.js: { }
+    /libraries/swiper/dist/js/swiper.min.js: { }
 
 infinite.social-apis:
   js:

--- a/js/infinite/views/base/base-list-swipeable-view.js
+++ b/js/infinite/views/base/base-list-swipeable-view.js
@@ -40,7 +40,7 @@
             this.$swiperContainer = this.$el.find('.container-content');
         },
         updateViews: function () {
-            this.swiperApi = this.$swiperContainer.swiper(this.settings);
+            this.swiperApi = new Swiper(this.$swiperContainer[0], this.settings);
             this.$swiperContainer.data('swiperApi', this.swiperApi);
 
             if (this.isMobileMode) {
@@ -74,7 +74,7 @@
             this.swiperApi.off('slideChangeStart');
         },
         removeSwiper: function () {
-            this.$swiperContainer.data('swiperApi').destroy(true, true);
+            this.swiperApi.destroy(true, true);
             this.$swiperContainer.removeData('swiperApi');
         },
         onDeviceBreakpointHandler: function (pModel) {

--- a/js/infinite/views/products/ecommerce-slider-view.js
+++ b/js/infinite/views/products/ecommerce-slider-view.js
@@ -12,7 +12,12 @@
       loop: true,
       slidesPerView: 'auto',
       grabCursor: true,
-      watchSlidesVisibility: true
+      watchSlidesVisibility: true,
+      preloadImages: false,
+      lazy: {
+        loadOnTransitionStart: true
+        //loadPrevNext: true
+      }
     },
     initialize: function (pOptions) {
       BaseDynamicView.prototype.initialize.call(this, pOptions);
@@ -30,17 +35,21 @@
       this.$swiperContainer = this.$el.find('.swiper-container');
 
       _.extend(this.settings, {
-        nextButton: this.$el.find('.swiper-button-next')[0],
-        prevButton: this.$el.find('.swiper-button-prev')[0]
+        navigation: {
+          nextEl: this.$el.find('.swiper-button-next')[0],
+          prevEl: this.$el.find('.swiper-button-prev')[0]
+        }
       });
 
-      if(this.$el.attr('data-slider') !== 'undefined'){
+      if (this.$el.attr('data-slider') !== 'undefined') {
         var $dataSlider = JSON.parse(this.$el.attr('data-slider'));
         _.extend(this.settings, $dataSlider);
       }
     },
     updateView: function () {
-      this.swiperApi = this.$swiperContainer.swiper(this.settings);
+
+      this.swiperApi = new Swiper(this.$swiperContainer[0], this.settings);
+      //this.swiperApi = this.$swiperContainer.swiper(this.settings);
       this.$swiperContainer.data('swiperApi', this.swiperApi);
 
       this.swiperApi.off('onSlideChangeEnd')

--- a/js/infinite/views/products/ecommerce-slider-view.js
+++ b/js/infinite/views/products/ecommerce-slider-view.js
@@ -5,9 +5,6 @@
   BurdaInfinite.views.products.EcommerceSliderView = BaseDynamicView.extend({
     $swiperContainer: [],
     swiperApi: null,
-    // deviceModel: null,
-    // breakpointDeviceModel: null,
-    // currentBreakpoint: null,
     settings: {
       loop: true,
       slidesPerView: 'auto',
@@ -16,7 +13,6 @@
       preloadImages: false,
       lazy: {
         loadOnTransitionStart: true
-        //loadPrevNext: true
       }
     },
     initialize: function (pOptions) {
@@ -25,11 +21,6 @@
       this.updateView();
       this.delegateInview();
       this.duplicateElementClick();
-
-      // this.deviceModel = BM.reuseModel(ModelIds.deviceModel);
-      // this.breakpointDeviceModel = this.deviceModel.getDeviceBreakpoints().findWhere({active: true});
-      // this.currentBreakpoint = this.breakpointDeviceModel.id;
-      // this.listenTo(this.deviceModel.getDeviceBreakpoints(), 'change:active', this.onDeviceBreakpointHandler, this);
     },
     createView: function () {
       this.$swiperContainer = this.$el.find('.swiper-container');
@@ -49,7 +40,6 @@
     updateView: function () {
 
       this.swiperApi = new Swiper(this.$swiperContainer[0], this.settings);
-      //this.swiperApi = this.$swiperContainer.swiper(this.settings);
       this.$swiperContainer.data('swiperApi', this.swiperApi);
 
       this.swiperApi.off('onSlideChangeEnd')

--- a/sass/mixins/_mixins.products.scss
+++ b/sass/mixins/_mixins.products.scss
@@ -627,7 +627,6 @@
     width: $ecommerce-slider__item_width--tablet;
     display: flex;
     flex-flow: column wrap;
-    align-items: flex-start;
   }
 
   .swiper-button-prev {

--- a/templates/media/image--product-ecommerce-slider.html.twig
+++ b/templates/media/image--product-ecommerce-slider.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Default theme implementation of an image.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the img tag.
+ * - style_name: (optional) The name of the image style applied.
+ *
+ * @see template_preprocess_image()
+ *
+ * @ingroup themeable
+ */
+#}
+
+<img class="swiper-lazy" data-src="{{ attributes['src'] }}"/>
+<div class="swiper-lazy-preloader">
+    <div class="_4-u2 mbm _2iwp">
+        <div class="_2iwo">
+            <div class="_2iwq">
+                <div class="_2iwr"></div>
+                <div class="_2iws"></div>
+                <div class="_2iwt"></div>
+                <div class="_2iwu"></div>
+                <div class="_2iwv"></div>
+                <div class="_2iww"></div>
+                <div class="_2iwx"></div>
+                <div class="_2iwy"></div>
+                <div class="_2iwz"></div>
+                <div class="_2iw-"></div>
+                <div class="_2iw_"></div>
+                <div class="_2ix0"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/media/image--product-ecommerce-slider.html.twig
+++ b/templates/media/image--product-ecommerce-slider.html.twig
@@ -14,23 +14,4 @@
 #}
 
 <img class="swiper-lazy" data-src="{{ attributes['src'] }}"/>
-<div class="swiper-lazy-preloader">
-    <div class="_4-u2 mbm _2iwp">
-        <div class="_2iwo">
-            <div class="_2iwq">
-                <div class="_2iwr"></div>
-                <div class="_2iws"></div>
-                <div class="_2iwt"></div>
-                <div class="_2iwu"></div>
-                <div class="_2iwv"></div>
-                <div class="_2iww"></div>
-                <div class="_2iwx"></div>
-                <div class="_2iwy"></div>
-                <div class="_2iwz"></div>
-                <div class="_2iw-"></div>
-                <div class="_2iw_"></div>
-                <div class="_2ix0"></div>
-            </div>
-        </div>
-    </div>
-</div>
+<div class="swiper-lazy-preloader"></div>

--- a/templates/product/advertising-product--ecommerce-slider.html.twig
+++ b/templates/product/advertising-product--ecommerce-slider.html.twig
@@ -20,7 +20,7 @@
 {% set classes = [
 'item-ecommerce',
 'item-product-slider',
-'swiper-slide',
+'swiper-slide'
 ] %}
 
 {% set data_attributes = data_attributes.setAttribute('data-view-type', 'productSliderView') %}


### PR DESCRIPTION
## [INREL-4135](https://jira.burda.com/browse/INREL-4135) 
- Update swiper.js lib from 3.4.2 to 4.3.3
- Include/Create swiper lazy loading template
- Change ecommerce-slider styling

## How to test:
- Checkout feature/INREL-4135-ecommerce-slider-lazyloading
- Open the network tab. 
- Go to a Ecommerce-Slider-Widget and swipe/click to the next product.

Now you should see that the next / perv product image are lazyloaded.

## Checklist:

- [ x ] I have verified that the code works
- [ x ] I have verified that the code is easy to understand
- [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
