### PR TITLE
INREL-4113: Update infinite.theme to properly set attributes

### DIFF
--- a/infinite.theme
+++ b/infinite.theme
@@ -200,12 +200,10 @@ function infinite_preprocess_advertising_product(&$variables) {
     ->setAttribute('data-currency', $product->product_currency->value)
     ->setAttribute('data-uuid', $product->uuid->value)
     ->setAttribute('data-product-id', $product->product_id->value)
-    ->setAttribute('data-sold-out', $product->product_sold_out->value)
-    ->setAttribute('data-external-url', $product->product_url->uri);
+    ->setAttribute('data-sold-out', $product->product_sold_out->value);
 
   // tracking_url
   $tracking_url = $product->product_url->uri;
-  
   // This is needed only for tracdelight products
   if ($product->getType() == 'advertising_product_tracdelight') {
     $sub_id = 0;
@@ -220,6 +218,7 @@ function infinite_preprocess_advertising_product(&$variables) {
     $tracking_url .= '&subid=' . $sub_id . '-' . $product->product_id->value;
   }
 
+  $data_attributes->setAttribute('data-external-url', $tracking_url);
   $variables['tracking_url'] = $tracking_url;
 
   // original_price

--- a/infinite.theme
+++ b/infinite.theme
@@ -203,7 +203,9 @@ function infinite_preprocess_advertising_product(&$variables) {
     ->setAttribute('data-sold-out', $product->product_sold_out->value)
     ->setAttribute('data-external-url', $product->product_url->uri);
 
+  // tracking_url
   $tracking_url = $product->product_url->uri;
+  
   // This is needed only for tracdelight products
   if ($product->getType() == 'advertising_product_tracdelight') {
     $sub_id = 0;
@@ -218,27 +220,37 @@ function infinite_preprocess_advertising_product(&$variables) {
     $tracking_url .= '&subid=' . $sub_id . '-' . $product->product_id->value;
   }
 
-  $original_price = $product->product_original_price->value;
-  $price = $product->product_price->value;
+  $variables['tracking_url'] = $tracking_url;
 
+  // original_price
+  $original_price = $product->product_original_price->value;
+
+  // price
+  $price = $product->product_price->value;
+ 
+  // provider
+  $provider = explode("_", $product->product_provider->value)[0];
+  $data_attributes->setAttribute('data-provider', $provider);
+  $variables['provider'] = $provider;
+
+  if ('tipser' === $provider) {
+    $data_attributes->setAttribute('data-tipser-url', $variables['tracking_url']);
+    $data_attributes->removeAttribute('data-external-url');
+  }
+
+  // sold_out
   $sold_out = $product->product_sold_out->value;
-  $in_stock = !isset($variables['sold_out']) || !$variables['sold_out'];
 
   if ($price <= 0 || $sold_out) {
     $variables['sold_out'] = TRUE;
   }
 
-  $provider = explode("_", $product->product_provider->value)[0];
-  $data_attributes->setAttribute('data-provider', $provider);
-  $variables['provider'] = $provider;
-
-  $original_price = $product->product_original_price->value;
   if(!isset($variables['sold_out']) || !$variables['sold_out']) {
     if($price < $original_price){
       $variables['show_strikethrough_price'] = TRUE;
       $variables['percentage_saving'] = floor(($price - $original_price) / $original_price * 100);
     }
-    $variables['tracking_url'] = $tracking_url;    if ('tipser' === $provider) {
+      if ('tipser' === $provider) {
       // hack so we can track product category even though it uses another field
       // for the category than e.g. Amazon products
       $tipserFieldCategory = $product->get('field_category');
@@ -249,15 +261,9 @@ function infinite_preprocess_advertising_product(&$variables) {
           $variables['tipser_product_category'] = $term->getName();
         }
       }
-
-      $data_attributes->setAttribute('data-tipser-url', $variables['tracking_url']);
       $data_attributes->setAttribute('data-shop', $product->product_shop->value);
-      $data_attributes->removeAttribute('data-external-url');
-    } else {
-      $data_attributes->setAttribute('data-external-url', $variables['tracking_url']);
     }
   }
-
 
   $variables['data_attributes'] = $data_attributes;
 }


### PR DESCRIPTION
## [INREL-4113](https://jira.burda.com/browse/INREL-4113) 
When clicking on a sold out tipser product it would open a  new tab.
This was due to data-external-url being set.

I removed it on tipser product and did a tiny bit of refactoring to make the code a little bit more structured.

## How to test:
- Open any page with a tipser product, i.e. /beauty/makelloser-teint-trotz-affenhitze-das-geht-und-zwar-mit-diesen-5-produkten
- Set product to sold out
- It should not open a new tab but only the layer for tipser


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
