### PR TITLE
INREL-4222: Fix margins on lexicon

### DIFF
--- a/sass/components/lexicon/_lexicon.scss
+++ b/sass/components/lexicon/_lexicon.scss
@@ -79,6 +79,7 @@
     .lexicon-teaser__letter {
       @extend %flexbox;
       flex-wrap: wrap;
+      margin-top: 0;
 
       .lexicon-teaser__item {
         flex-grow: 1;

--- a/sass/components/lexicon/_lexicon.variables.scss
+++ b/sass/components/lexicon/_lexicon.variables.scss
@@ -10,6 +10,6 @@ $lexicon-teaser__title--margin-top__tablet: 6px;
 
 $lexicon-teaser__copy--margin-top__mobile: 6px;
 
-$lexicon-teaser--margin-top: 10px;
+$lexicon-teaser--margin-top: 32px;
 
 $lexicon-teaser__placeholder--background-color: #F1F1F1;


### PR DESCRIPTION
## [INREL-4222](https://jira.burda.com/browse/INREL-4222) 
Increased margins to 32px as per Zeplin design

## How to test:
 - http://elle.dev.local/modelexicon
 - ensure `.lexicon-teaser__item` has a `margin-top: 32px`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
