### PR TITLE
INREL-4268: Add JS variable atf_disable_oil to disable consent on FIA

### DIFF
--- a/templates/ads/adtech-iframe.html.twig
+++ b/templates/ads/adtech-iframe.html.twig
@@ -1,0 +1,34 @@
+<iframe width='{{ iframe.width }}' height='{{ iframe.height }}' srcdoc='
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ iframe.title }}</title>
+    <script type="text/javascript">
+      // Disable consent layer. Related to INREL-4268.
+      var atf_disable_oil = true;
+    </script>
+    <script src="{{ library_source }}" type="text/javascript"></script>
+    <script type="text/javascript">
+      var page_targeting = {{ page_targeting|raw }};
+      if (typeof atf_lib !== "undefined") {
+        for (var key in page_targeting) {
+          if (page_targeting.hasOwnProperty(key)) {
+            atf_lib.add_page_targeting(key, page_targeting[key]);
+          }
+        }
+      }
+    </script>
+  </head>
+  <body>
+  <div{{ attributes }}></div>
+  <script type="text/javascript">
+    atf_lib.load_tag([{
+      element: document.getElementById("{{- attributes.id -}}"),
+      targeting: {{ targeting|raw }}
+    }]);
+  </script>
+  </body>
+  </html>
+  '>
+</iframe>


### PR DESCRIPTION
## [INREL-4268](https://jira.burda.com/browse/INREL-4268) 
To disable consent box on FIA iframe ads we have to add following JS variable to FIA adtech iframe ad.

      var atf_disable_oil = true;

- Clone adtech-iframe.html.twig file from ad_entity_adtech sub-module to templates/ads folder.
- Add script-tag with atf_disable_oil variable to cloned TWIG file.

## How to test:
Ads on FIA should not display consent box any more.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [x] I have documented the changes (where applicable)
