### PR TITLE
INREL-4414: Update native campaign to use inline rendered SVG

### DIFF
--- a/templates/native_campaign/native_campaign.html.twig
+++ b/templates/native_campaign/native_campaign.html.twig
@@ -21,7 +21,7 @@
   </span>
   <span class="separator">&</span>
   <span class="brand">
-    {{ content.logo }}
+    {{ campaign_logo | raw }}
   </span>
   {{ content.tracking_pixel }}
 </div>


### PR DESCRIPTION
## [INREL-4414](https://jira.burda.com/browse/INREL-4414) 
SVG Icons are not displayed on Non-AMP Pages.

Externally referenced SVGs don't work with SVGs which have been optimized for AMP.
In order to make them work for NON-AMP pages we need to render all SVGs inline.

In this PR I used existing logic from AMP pages to render them inline.

## How to test:
Please refer to test instructions in ticket


## Checklist:
- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
