### PR TITLE
INREL-4302: Layout Issue when Sold Out Product has no Price

### DIFF
--- a/templates/product/advertising-product-inner.html.twig
+++ b/templates/product/advertising-product-inner.html.twig
@@ -1,3 +1,4 @@
+{% set AMAZON_EMPTY_PRICE = '0,00' %}
 {% block product__img_container_block %}
     <div class="img-container">
         {{ content.product_image }}
@@ -10,7 +11,7 @@
         {% if sold_out %}
                 <div class="text-price">
                     <span class="text-price--current">
-                        {% if content.product_price.0|render != '0,00' %}
+                        {% if content.product_price.0|render != AMAZON_EMPTY_PRICE %}
                             {{ content.product_price }} {{ formatted_currency }}
                         {% endif %}
                     </span>

--- a/templates/product/advertising-product-inner.html.twig
+++ b/templates/product/advertising-product-inner.html.twig
@@ -8,11 +8,13 @@
         <div class="text-brand">{{ content.product_brand }}</div>
         <div class="text-headline">{{ content.product_name }}</div>
         {% if sold_out %}
-            {% if content.product_price.0|render != '0,00' %}
                 <div class="text-price">
-                    <span class="text-price--current">{{ content.product_price }} {{ formatted_currency }}</span>
+                    <span class="text-price--current">
+                        {% if content.product_price.0|render != '0,00' %}
+                            {{ content.product_price }} {{ formatted_currency }}
+                        {% endif %}
+                    </span>
                 </div>
-            {% endif %}
             <div class="text-shop text-sold-out">Ausverkauft</div>
         {% else %}
             <div class="text-price">

--- a/templates/product/advertising-product-inner.html.twig
+++ b/templates/product/advertising-product-inner.html.twig
@@ -1,4 +1,7 @@
 {% set AMAZON_EMPTY_PRICE = '0,00' %}
+{% set product_price = content.product_price.0|render %}
+{% set product_price_set =  product_price != AMAZON_EMPTY_PRICE and product_price is not empty %}
+
 {% block product__img_container_block %}
     <div class="img-container">
         {{ content.product_image }}
@@ -11,7 +14,7 @@
         {% if sold_out %}
                 <div class="text-price">
                     <span class="text-price--current">
-                        {% if content.product_price.0|render != AMAZON_EMPTY_PRICE %}
+                        {% if product_price_set %}
                             {{ content.product_price }} {{ formatted_currency }}
                         {% endif %}
                     </span>


### PR DESCRIPTION
## [INREL-4302](https://jira.burda.com/browse/INREL-4302) 
Sold out products with no price aligned the "sold out" button incorrectly.

## How to test:
 - Check ecommerce slider with the following [product](https://www.amazon.de/Clarisonic-Mia2-Rosa-Pink-Mia/dp/B0057RRBHQ?psc=1&SubscriptionId=AKIAJTXCIRHS3BHL4FLQ&tag=e0bb5-slider-21&linkCode=xm2&camp=2025&creative=165953&creativeASIN=B0057RRBHQ)

 - https://github.com/BurdaMagazinOrg/elle-web/pull/178
 - https://github.com/BurdaMagazinOrg/bazaar-web/pull/150
 - https://github.com/BurdaMagazinOrg/freundin-web/pull/198

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
