### PR TITLE
INREL-4308 change eventNonInteraction to true

### DIFF
--- a/js/infinite/libs/shortcuts/infinite_custom.js
+++ b/js/infinite/libs/shortcuts/infinite_custom.js
@@ -104,7 +104,7 @@
       TrackingManager.trackEvent({
         category: 'lazy-loading',
         action: this.$more.attr('href'),
-        eventNonInteraction: false
+        eventNonInteraction: true
       });
     }
 


### PR DESCRIPTION
## [INREL-4308](https://jira.burda.com/browse/INREL-4308) 
Set lazy-loading event to `eventNonInteraction: true`

## How to test:
Open one of our pages and enable the console. Scroll down to the next lazyloading block.
Now you should see a `>> trackEvent: category: 'lazy-loadng'`. Check the `eventNonInteraction` attribute. 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
