### PR TITLE
INREL-4568: added default values for featureActive and abTestActive

### DIFF
--- a/js/infinite/utils/ab-testing.js
+++ b/js/infinite/utils/ab-testing.js
@@ -27,7 +27,7 @@ function ABTest(feature) {
   this.getTestObject = () => this.assignedGroups.find(item => item.feature === this.abTest.feature);
 
   this.showUserContent = () => {
-    const abTest = this.getTestObject();
+    const abTest = Object.assign({ featureActive: true, abTestActive: true }, this.getTestObject());
     const abTestAllows = !abTest.abTestActive || this.abTest.group === 'a';
     return abTest.featureActive && abTestAllows;
   };


### PR DESCRIPTION
## [INREL-4568](https://jira.burda.com/browse/INREL-4568) 
Added default values  for `featureActive` and `abTestActive`

## How to test:
 - open article
 - check AB Group is `a` for `Next Article Trigger`
 - check next article trigger is loaded

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
