### PR TITLE
INREL-4563: Override AB Test via URL

### DIFF
--- a/js/infinite/utils/ab-testing.js
+++ b/js/infinite/utils/ab-testing.js
@@ -9,9 +9,11 @@ function ABTest(feature) {
     this.abTest = { feature };
     this.abTest.group = this.getABGroup() || this.setABGroup();
 
+    this.applyUrlOverrideParams();
+
     if (!this.getABGroup()) {
       this.assignedGroups.push(this.abTest);
-      window.localStorage.setItem('abTests', JSON.stringify(this.assignedGroups));
+      this.writeToLocalStorage();
     }
     window.dataLayer.push({ event: 'executeABTest', abTest: this.abTest });
   };
@@ -21,6 +23,28 @@ function ABTest(feature) {
   this.getABGroup = () => {
     const result = this.assignedGroups.find(obj => obj.feature === this.abTest.feature, this);
     return !!result && result.group;
+  };
+
+  this.applyUrlOverrideParams = () => {
+    if (this.getUrlOverrideParam()) {
+      const override = this.getUrlOverrideParam();
+      this.assignedGroups = this.assignedGroups.filter(item => item.feature !== override.feature);
+      this.assignedGroups.push(override);
+      this.writeToLocalStorage();
+    }
+  };
+
+  this.writeToLocalStorage = () => {
+    window.localStorage.setItem('abTests', JSON.stringify(this.assignedGroups));
+  };
+
+  this.getUrlOverrideParam = () => {
+    const url = new URL(window.location.href);
+    const abGroup = {
+      feature: url.searchParams.get('abFeature'),
+      group: url.searchParams.get('abGroup'),
+    };
+    return !!abGroup.feature && !!abGroup.group ? abGroup : false;
   };
 
   this.getAllTests = () => JSON.parse(window.localStorage.getItem('abTests'));


### PR DESCRIPTION
## [INREL-4563](https://jira.burda.com/browse/INREL-4563) 
Override AB Tests via URL Parameter

## How to test:
 - Add Url parameters `abGroup` and `abFeature` to Url
 - Check localStorage item `abGroups` to see if value has been overridden

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
