### PR TITLE
INREL-4650 ie11 picturefill - advagg preprocess: false fix

### DIFF
--- a/infinite.libraries.yml
+++ b/infinite.libraries.yml
@@ -46,6 +46,7 @@ infinite.libs:
     js/infinite/libs/shortcuts/sticky.js: {}
     js/infinite/libs/shortcuts/inview.js: {}
     js/infinite/libs/jquery.inview.js: {}
+    ../../../core/assets/vendor/picturefill/picturefill.min.js: {preprocess: false}
 
 infinite.init:
   css:
@@ -68,7 +69,7 @@ infinite.init:
     - core/drupal.ajax
     - core/drupalSettings
     - core/jquery.once
-    - core/picturefill
+    # - core/picturefill
     - blazy/blazy
 
 infinite.utils.ab-testing:


### PR DESCRIPTION
## [INREL-4650](https://jira.burda.com/browse/INREL-4650) 
Exlude `picturefill.js lib` from `advagg module`.

## How to test:
Check if pictures will be loaded in IE11.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
