### PR TITLE
INREL-4584 change newsletter privacy text to ajax content + small cle…

### DIFF
--- a/js/infinite/views/base/base-newsletter-view.js
+++ b/js/infinite/views/base/base-newsletter-view.js
@@ -80,8 +80,11 @@
             this.available = true;
 
             if (this.useAjaxPermissions) {
-
-                this.$formView.find('.privacy-link').unbind('click.privacy_open').bind('click.privacy_open', $.proxy(function () {
+                
+                this.$privacyView.find('.container-content-dynamic').empty().append($(this.permissions.datenschutzeinwilligung.markup.text_body));
+                this.$formView.find('.privacy-text').empty().append($(this.permissions.datenschutzeinwilligung.markup.text_label));
+                
+                this.$formView.find('.privacy-text a').unbind('click.privacy_open').bind('click.privacy_open', $.proxy(function () {
                     this.setViewState(BaseNewsletterView.STATE_PRIVACY);
                     return false;
                 }, this));
@@ -90,7 +93,6 @@
                     this.setViewState(BaseNewsletterView.STATE_INITIAL);
                 }, this));
 
-                this.$privacyView.find('.container-content-dynamic').empty().append($(this.permissions.datenschutzeinwilligung.markup.text_body));
             }
         },
     formSubmit (pEvent) {

--- a/sass/mixins/_mixins.newsletter.scss
+++ b/sass/mixins/_mixins.newsletter.scss
@@ -14,7 +14,12 @@
     .container-privacy {
       @extend %fade-in;
       overflow-y: scroll;
+      
+      .content-wrapper {
+        position: relative
+      }
     }
+
   }
 
   &.state-success {
@@ -70,7 +75,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: $bg-color-gray-light;
+    background-color: $newsletter__content-item-bg-color;
   }
 
   .container-privacy, .container-success {
@@ -80,9 +85,19 @@
     line-height: 1.5;
   }
 
+  .container-success {
+    p {
+      margin-top: $gap-size-xxs;
+    }
+  }
+
   .container-privacy {
     text-align: left;
     padding: $grid-gutter-width;
+
+    p {
+      margin-top: $gap-size-xs;
+    }
 
     strong {
       @extend %text-headline;
@@ -101,7 +116,7 @@
 
   .container-form {
     @extend %fade-in;
-    background-color: transparent;
+    background-color: $newsletter__contianer-form-bg;
 
     .text-description {
       margin-bottom: $gap-section;
@@ -122,10 +137,6 @@
     button {
       @include newsletter__submit-button--horizontal;
     }
-
-    p {
-      line-height: 1.5;
-    }
   }
 
   .checkbox {
@@ -137,7 +148,7 @@
     font-size: $icon-size-medium;
     color: $text-color;
     top: $padding;
-    right: $grid-gutter-width;
+    right: $gap-size-xxs;
     z-index: 2;
   }
 
@@ -175,10 +186,6 @@
     }
 
     .container-form {
-      p {
-        font-size: 14px;
-      }
-
       .input-email {
         width: 100%;
         //padding-right: $padding-large-horizontal;
@@ -195,10 +202,6 @@
 
     .container-content-item {
       padding: $newsletter--horizontal--padding-mobile;
-
-      p {
-        margin-top: $padding;
-      }
     }
 
     .form-group--email {
@@ -314,10 +317,6 @@
     .container-privacy {
       display: block;
     }
-
-    .icon-close {
-      right: 35px;
-    }
   }
 
   @media (min-width: $screen-sm-min) and (max-width: $screen-md-max) {
@@ -341,7 +340,7 @@
       color: $text-color;
 
       .content-wrapper {
-        background-color: rgba($white, 0.8);
+        background-color: $newsletter-page__content-wrapper-bg-color;
         position: relative;
         width: $screen-sm-min;
         height: 400px;

--- a/sass/variables/_variables.newsletter.scss
+++ b/sass/variables/_variables.newsletter.scss
@@ -27,9 +27,9 @@ $newsletter--horizontal--padding-mobile: $gap-size-sm $gap-size-sm !default;
 $newsletter--horizontal--padding-tablet: $gap-size-sm $gap-size-sm !default;
 $newsletter--horizontal--padding-desktop: $gap-size-sm $gap-size-sm !default;
 
-$newsletter--horizontal--height-mobile: 420px !default;
-$newsletter--horizontal--height-tablet: 367px !default;
-$newsletter--horizontal--height-desktop: 367px !default;
+$newsletter--horizontal--height-mobile: 440px !default;
+$newsletter--horizontal--height-tablet: 387px !default;
+$newsletter--horizontal--height-desktop: 387px !default;
 
 $newsletter__bg-image--horizontal-mobile: "../images/static/block-newsletter-sm.jpg" !default;
 $newsletter__bg-image--horizontal-tablet: "../images/static/block-newsletter-md.jpg" !default;
@@ -82,3 +82,7 @@ $newsletter__col-left-columns--modal: ($grid-columns / 2) !default;
 $newsletter__col-right-columns--modal: ($grid-columns / 2) !default;
 $newsletter__logo-margin--modal: 0 0 40px 0 !default;
 $newsletter__z-index--modal: 999999 !default;
+
+$newsletter__contianer-form-bg: transparent !default;
+$newsletter__content-item-bg-color: $bg-color-gray-light !default;
+$newsletter-page__content-wrapper-bg-color: rgba($white, 0.8) !default;;

--- a/sass/variables/_variables.newsletter.scss
+++ b/sass/variables/_variables.newsletter.scss
@@ -85,4 +85,4 @@ $newsletter__z-index--modal: 999999 !default;
 
 $newsletter__contianer-form-bg: transparent !default;
 $newsletter__content-item-bg-color: $bg-color-gray-light !default;
-$newsletter-page__content-wrapper-bg-color: rgba($white, 0.8) !default;;
+$newsletter-page__content-wrapper-bg-color: rgba($white, 0.8) !default;


### PR DESCRIPTION
## [INREL-4584](https://jira.burda.com/browse/INREL-4584) 
The newsletter privacy text has now dynamic text from the newsletter API.

## How to test:
Scroll down to the newsletter block on the homepage. Open the console use this code snippet: 

`
                window.thsixtyQ.push(['permissions.get', {
                    success: _.bind(function (pPermissions) {
                        console.log("success", pPermissions);
                    }, this),
                    error: _.bind(function (pErr) {
                        console.log("error", pErr);
                    }, this)
                }]);
`

You can check the dynamic api text `datenschutzeinwilligung > markup > text_label`.

After clicking the `hier` link in the privacy text - you will see the overlay with the API privacy text
-> `datenschutzeinwilligung > markup > text_body`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
