### PR TITLE
fix missing gap in recent ecommerce paragraph on bazaar INREL-5069

### DIFF
--- a/sass/components/_products.scss
+++ b/sass/components/_products.scss
@@ -1,6 +1,6 @@
 .item-paragraph--advertising-products-paragraph.item-paragraph--default,
 .item-paragraph--advertising-products-embed {
-  .item-product {
+  .item-product, .teaser-wrapper {
     @include product__item--default();
     @include product__item--horizontal-block();
   }


### PR DESCRIPTION
## [https://jira.burda.com/browse/INREL-5069](https://jira.burda.com/browse/INREL-5069) 
bazaar was missing the margin because of feed teaser wrapper
