### PR TITLE
Feature/inrel 5169 remove author header if spotlight content is present

### DIFF
--- a/infinite.theme
+++ b/infinite.theme
@@ -2,9 +2,7 @@
 
 use Drupal\Core\Template\Attribute;
 use Drupal\block\Entity\Block;
-use Drupal\image\Entity\ImageStyle;
 use Drupal\infinite_media\MediaHelper;
-use Drupal\views\Views;
 use Psy\Util\Json;
 
 function infinite_preprocess(&$variables) {
@@ -451,27 +449,40 @@ function _infinite_get_icon($node, $variables) {
   return $variables;
 }
 
-
+/**
+ * Set infinite preprocess variables for User
+ *
+ * @param $variables
+ *
+ * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+ */
 function infinite_preprocess_user(&$variables)  {
-  $hasSpotlightContent = false;
-  /** @var \Drupal\user\Entity\User $user */
-  $user = $variables['elements']['#user'];
+  try {
+    $variables['has_spotlight_content'] = getUserParagraphBundle($variables['elements']['#user']) === 'spotlight' ? true : false;
+  }catch (InvalidArgumentException $ex) {
+    $variables['has_spotlight_content'] = false;
+  }
+}
+
+/**
+ * Get the paragraph bundle
+ *
+ * @param \Drupal\user\Entity\User $user
+ * @param int|0 $paragraphPosition
+ *
+ * @return string
+ *
+ * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+ */
+function getUserParagraphBundle(\Drupal\user\Entity\User $user, int $paragraphPosition = 0): string {
   /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $fieldParagraphs */
   $fieldParagraphs = $user->getFields(true)['field_paragraphs'];
-  $paragraphsIterator = $fieldParagraphs->getIterator();
-  while($paragraphsIterator->valid()) {
-    /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $currentParagraph */
-    $currentParagraph = $paragraphsIterator->current();
-    /** @var \Drupal\paragraphs\Entity\Paragraph $paragraphEntity */
-    $paragraphEntity = $currentParagraph->get('entity')->getTarget()->getValue();
-    $type = $paragraphEntity->bundle();
-    if($type === 'spotlight') {
-      $hasSpotlightContent = true;
-      break;
-    }
-    $paragraphsIterator->next();
+  /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $currentParagraph */
+  $currentParagraph = $fieldParagraphs->get($paragraphPosition);
+  if(null === $currentParagraph)  {
+    throw new InvalidArgumentException(
+      sprintf('Paragraph at position %d is not present', $paragraphPosition)
+    );
   }
-
-  $variables['has_spotlight_content'] = $hasSpotlightContent;
-
+  return $currentParagraph->get('entity')->getTarget()->getValue()->bundle();
 }

--- a/infinite.theme
+++ b/infinite.theme
@@ -450,3 +450,28 @@ function _infinite_get_icon($node, $variables) {
 
   return $variables;
 }
+
+
+function infinite_preprocess_user(&$variables)  {
+  $hasSpotlightContent = false;
+  /** @var \Drupal\user\Entity\User $user */
+  $user = $variables['elements']['#user'];
+  /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $fieldParagraphs */
+  $fieldParagraphs = $user->getFields(true)['field_paragraphs'];
+  $paragraphsIterator = $fieldParagraphs->getIterator();
+  while($paragraphsIterator->valid()) {
+    /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $currentParagraph */
+    $currentParagraph = $paragraphsIterator->current();
+    /** @var \Drupal\paragraphs\Entity\Paragraph $paragraphEntity */
+    $paragraphEntity = $currentParagraph->get('entity')->getTarget()->getValue();
+    $type = $paragraphEntity->bundle();
+    if($type === 'spotlight') {
+      $hasSpotlightContent = true;
+      break;
+    }
+    $paragraphsIterator->next();
+  }
+
+  $variables['has_spotlight_content'] = $hasSpotlightContent;
+
+}

--- a/infinite.theme
+++ b/infinite.theme
@@ -461,7 +461,7 @@ function _infinite_get_icon($node, $variables) {
 function infinite_preprocess_user(&$variables)
 {
   try {
-    $variables['has_spotlight_paragraph'] = infinite_get_user_paragraph_bundle($variables['elements']['#user']) === 'spotlight' ? true : false;
+    $variables['has_spotlight_paragraph'] = infinite_get_user_paragraph_bundle($variables['elements']['#user']) === 'spotlight';
   } catch (InvalidArgumentException $ex) {
     $variables['has_spotlight_paragraph'] = false;
   } catch (MissingDataException $ex) {

--- a/infinite.theme
+++ b/infinite.theme
@@ -2,10 +2,10 @@
 
 use Drupal\Core\Template\Attribute;
 use Drupal\block\Entity\Block;
+use Drupal\Core\TypedData\Exception\MissingDataException;
 use Drupal\infinite_media\MediaHelper;
 use Drupal\user\Entity\User;
 use Psy\Util\Json;
-
 
 function infinite_preprocess(&$variables) {
   $variables['environment'] = ['systemType' =>  isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : 'local'];
@@ -458,30 +458,35 @@ function _infinite_get_icon($node, $variables) {
  *
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
-function infinite_preprocess_user(&$variables)  {
+function infinite_preprocess_user(&$variables)
+{
   try {
-    $variables['has_spotlight_content'] = infinite_get_user_paragraph_bundle($variables['elements']['#user']) === 'spotlight' ? true : false;
-  }catch (InvalidArgumentException $ex) {
-    $variables['has_spotlight_content'] = false;
+    $variables['has_spotlight_paragraph'] = infinite_get_user_paragraph_bundle($variables['elements']['#user']) === 'spotlight' ? true : false;
+  } catch (InvalidArgumentException $ex) {
+    $variables['has_spotlight_paragraph'] = false;
+  } catch (MissingDataException $ex) {
+    $variables['has_spotlight_paragraph'] = false;
   }
 }
 
 /**
  * Get the paragraph bundle
  *
- * @param \Drupal\user\Entity\User $user
- * @param int|0 $paragraphPosition
+ * @param User $user
+ * @param int $paragraphPosition
  *
  * @return string
  *
+ * @throws InvalidArgumentException
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
-function infinite_get_user_paragraph_bundle(User $user, int $paragraphPosition = 0): string {
+function infinite_get_user_paragraph_bundle(User $user, int $paragraphPosition = 0): string
+{
   /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $fieldParagraphs */
   $fieldParagraphs = $user->getFields(true)['field_paragraphs'];
   /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $currentParagraph */
   $currentParagraph = $fieldParagraphs->get($paragraphPosition);
-  if (null === $currentParagraph)  {
+  if (null === $currentParagraph) {
     throw new InvalidArgumentException("Paragraph at position '$paragraphPosition' is not present");
   }
   return $currentParagraph->get('entity')->getTarget()->getValue()->bundle();

--- a/infinite.theme
+++ b/infinite.theme
@@ -3,7 +3,9 @@
 use Drupal\Core\Template\Attribute;
 use Drupal\block\Entity\Block;
 use Drupal\infinite_media\MediaHelper;
+use Drupal\user\Entity\User;
 use Psy\Util\Json;
+
 
 function infinite_preprocess(&$variables) {
   $variables['environment'] = ['systemType' =>  isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : 'local'];
@@ -458,7 +460,7 @@ function _infinite_get_icon($node, $variables) {
  */
 function infinite_preprocess_user(&$variables)  {
   try {
-    $variables['has_spotlight_content'] = getUserParagraphBundle($variables['elements']['#user']) === 'spotlight' ? true : false;
+    $variables['has_spotlight_content'] = infinite_get_user_paragraph_bundle($variables['elements']['#user']) === 'spotlight' ? true : false;
   }catch (InvalidArgumentException $ex) {
     $variables['has_spotlight_content'] = false;
   }
@@ -474,15 +476,13 @@ function infinite_preprocess_user(&$variables)  {
  *
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
-function getUserParagraphBundle(\Drupal\user\Entity\User $user, int $paragraphPosition = 0): string {
+function infinite_get_user_paragraph_bundle(User $user, int $paragraphPosition = 0): string {
   /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $fieldParagraphs */
   $fieldParagraphs = $user->getFields(true)['field_paragraphs'];
   /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $currentParagraph */
   $currentParagraph = $fieldParagraphs->get($paragraphPosition);
-  if(null === $currentParagraph)  {
-    throw new InvalidArgumentException(
-      sprintf('Paragraph at position %d is not present', $paragraphPosition)
-    );
+  if (null === $currentParagraph)  {
+    throw new InvalidArgumentException("Paragraph at position '$paragraphPosition' is not present");
   }
   return $currentParagraph->get('entity')->getTarget()->getValue()->bundle();
 }

--- a/templates/user/user--default.html.twig
+++ b/templates/user/user--default.html.twig
@@ -32,9 +32,9 @@
             <div class="item-author__profile-image">
                 {{ content.user_picture }}
             </div>
-            {% if content.has_header_block and not has_spotlight_content %}
+            {% if content.has_header_block and not has_spotlight_paragraph %}
                 <h2 class="item-author__name">{{ content.field_full_name }}</h2>
-            {% elseif not has_spotlight_content %}
+            {% elseif not has_spotlight_paragraph %}
                 <h1 class="item-author__name">{{ content.field_full_name }}</h1>
             {% endif %}
             <div class="item-author__job">

--- a/templates/user/user--default.html.twig
+++ b/templates/user/user--default.html.twig
@@ -32,9 +32,9 @@
             <div class="item-author__profile-image">
                 {{ content.user_picture }}
             </div>
-            {% if content.has_header_block %}
+            {% if content.has_header_block and not has_spotlight_content %}
                 <h2 class="item-author__name">{{ content.field_full_name }}</h2>
-            {% else %}
+            {% elseif not has_spotlight_content %}
                 <h1 class="item-author__name">{{ content.field_full_name }}</h1>
             {% endif %}
             <div class="item-author__job">

--- a/templates/user/user--default.html.twig
+++ b/templates/user/user--default.html.twig
@@ -27,23 +27,22 @@
     {% block content_header_block %}{% endblock %}
 
     <div{{ attributes.addClass(wrapper_classes) }} >
-
+      {% if not has_spotlight_paragraph %}
         <div class="item-author--detail-large">
-            <div class="item-author__profile-image">
-                {{ content.user_picture }}
-            </div>
-            {% if content.has_header_block and not has_spotlight_paragraph %}
-                <h2 class="item-author__name">{{ content.field_full_name }}</h2>
-            {% elseif not has_spotlight_paragraph %}
-                <h1 class="item-author__name">{{ content.field_full_name }}</h1>
-            {% endif %}
-            <div class="item-author__job">
-                {{ content.field_job_title }}
-            </div>
-            <div class="item-author__short-info">
-                {{ content.field_profile_text }}
-            </div>
-
+                <div class="item-author__profile-image">
+                  {{ content.user_picture }}
+                </div>
+                {% if content.has_header_block %}
+                  <h2 class="item-author__name">{{ content.field_full_name }}</h2>
+                {% else %}
+                  <h1 class="item-author__name">{{ content.field_full_name }}</h1>
+                {% endif %}
+                <div class="item-author__job">
+                  {{ content.field_job_title }}
+                </div>
+                <div class="item-author__short-info">
+                  {{ content.field_profile_text }}
+                </div>
             {% block user_author_socials %}
                 <div class="item-author__socials">
 
@@ -121,7 +120,7 @@
                 </div>
             {% endblock %}
         </div>
-
+      {% endif %}
         {% block content_block %}
             {{ content.field_paragraphs }}
         {% endblock %}


### PR DESCRIPTION
## [INREL-5169](https://jira.burda.com/browse/INREL-5169) 
from the ticket:
Please include a summary of the changes provided with this pull request and which issue has been As an SEO Manager I dont want to have a Spotlight Element + a Header on Author profiles. 
I want the same behaviour of the page like a term page (e.g. https://www.instyle.de/frisuren/flechtfrisuren) has: if there is no spotlight element a header is shown. however if there is a spotlight element the header is hidden.

## How to test:
Just add and remove a spotlight paragraph from an author and see if the spotlight paragraph is shown.
Basically the spotlight content has always the priority, if it is present then it must be shown and the header of the Author must disappear. 