### PR TITLE
INREL-5629 fix flexbox content teaser fix on safari

### DIFF
--- a/sass/mixins/_mixins.lists.scss
+++ b/sass/mixins/_mixins.lists.scss
@@ -80,7 +80,7 @@
 
   @media (min-width: $screen-sm-min) {
     float: left;
-    width: percentage(($grid-columns / $item-count) / $grid-columns);
+    width: floor(percentage(($grid-columns / $item-count) / $grid-columns));
   }
 
   @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {


### PR DESCRIPTION
## [INREL-5629](https://jira.burda.com/browse/INREL-5629) 
Actual Behavior: The Content Teaser and Recent Content Paragraph have a different style on Safari. The selected layout is "Schmal". 

Expected Behavior: The Content Teaser and Recent Content Paragraph should have on all Platforms the same style.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
