### PR TITLE
INREL-5677: stop tipser click opening in new tab

### DIFF
--- a/js/infinite/views/products/product-view.js
+++ b/js/infinite/views/products/product-view.js
@@ -174,7 +174,8 @@
           break;
       }
 
-      if (externalTrackingURL != this.$el.attr('data-external-url')) {
+      if (externalTrackingURL != this.model.get('url')) {
+        this.model.set('tracking-url', externalTrackingURL);
         this.$el.attr('data-external-url', externalTrackingURL);
       }
     },


### PR DESCRIPTION
## [INREL-5677](https://jira.burda.com/browse/INREL-5677) 
 - stops new window opening when clicking on tipser product

## How to test:
 - http://instyle.dev.local
 - click on tipser item
 -- opens in overlay
 -- new tab doesn't open
 - click on non tipser item
 -- opens in new tab

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
