### PR TITLE
feat: don't attach library product-view.js for advertising product paragraph preview

### DIFF
--- a/templates/product/advertising-product.html.twig
+++ b/templates/product/advertising-product.html.twig
@@ -25,3 +25,7 @@
 {% set data_attributes = data_attributes.setAttribute('data-view-type', 'productView') %}
 
 {% extends '@infinite/product/advertising-product-outer.html.twig' %}
+{% if displayMode == 'preview' %}
+  {% block product_attach_library %}
+  {% endblock %}
+{% endif %}


### PR DESCRIPTION
## [INREL-6255](https://jira.burda.com/browse/INREL-6255) 
Does not attach `product-view.js` when displayed in backend.

## How to test:
 - https://bazaar.local/node/47061/edit
 - add products paragraph
 - add product
 - save/publish article
 - return to article
 - check for no javascript error

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
