### PR TITLE
INREL-6515 set view_mode doestn work in drupal block / fix broken sin…

### DIFF
--- a/templates/product/mustache/products.html.twig
+++ b/templates/product/mustache/products.html.twig
@@ -2,7 +2,7 @@
 {% if view_mode == 'single-product' %}
   {# refactor css class / use machine_name for new products css selector #}
   {% set view_mode = 'single' %}
-{% endif %} 
+{% endif %}
 
 {% block product_outer_block %}
   {% if showAffiliateLinkLabel and view_mode != 'single' %}

--- a/templates/product/mustache/products.html.twig
+++ b/templates/product/mustache/products.html.twig
@@ -1,10 +1,10 @@
 
-{% block product_outer_block %}
-  {% if view_mode == 'single-product' %}
-    {# refactor css class / use machine_name for new products css selector #}
-    {% set view_mode = 'single' %}
-  {% endif %} 
+{% if view_mode == 'single-product' %}
+  {# refactor css class / use machine_name for new products css selector #}
+  {% set view_mode = 'single' %}
+{% endif %} 
 
+{% block product_outer_block %}
   {% if showAffiliateLinkLabel and view_mode != 'single' %}
     <div class="affiliatelinks">
         <a href="/affiliatelinks" rel="nofollow" target="_self">Affiliatelinks</a>


### PR DESCRIPTION
## [INREL-6515](https://jira.burda.com/browse/INREL-6515) 
Fix broken single-products. Seems that 

`{% set view_mode = 'single' %}` doestn work in a drupal_block?
when I set the view_mode outside the `{% block product_outer_block %}` everything works fine.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
