### PR TITLE
INREL-6616: Fix missing Amazon tag related drupalSettings

### DIFF
--- a/infinite.theme
+++ b/infinite.theme
@@ -328,7 +328,11 @@ function infinite_preprocess_paragraph(&$variables) {
   // Initialise amazon id.
   _infinite_add_amazon_id($variables);
   // Overwrite the default amazon associates_id if set.
-  if ('products' === $variables['paragraph']->bundle() || 'ecommerce_slider_paragraph' === $variables['paragraph']->bundle()) {
+  if ('products' === $variables['paragraph']->bundle()
+    || 'advertising_products_paragraph' === $variables['paragraph']->bundle()
+    || 'advertising_products_embed' === $variables['paragraph']->bundle()
+    || 'ecommerce_slider_paragraph' === $variables['paragraph']->bundle()) {
+
     $node_entity = \Drupal::routeMatch()->getParameter('node');
     if (
       $node_entity instanceof \Drupal\node\Entity\Node


### PR DESCRIPTION
Added our old eCommerce paragraphs to fix missing Amazon tag related drupalSettings on articles without eCommerce slider.