### PR TITLE
INREL-4927 top deals

### DIFF
--- a/sass/components/coupon/_coupon.scss
+++ b/sass/components/coupon/_coupon.scss
@@ -19,7 +19,7 @@
 @import 'coupon.filter';
 
 #content .item-content--coupon.sticky .coupon__row {
-  background-color: $color-pink;
+  background-color: $coupon__top-deal--bg-color;
   padding: $grid-unit-2;
 
   @media (max-width: $screen-xs-max) {

--- a/sass/components/coupon/_coupon.scss
+++ b/sass/components/coupon/_coupon.scss
@@ -1,5 +1,5 @@
 %collapse-icon {
-  @include icon($container: "&:after");
+  @include icon($container: '&:after');
   position: relative;
   cursor: pointer;
 
@@ -15,10 +15,35 @@
   }
 }
 
-@import "coupon.overview";
-@import "coupon.filter";
+@import 'coupon.overview';
+@import 'coupon.filter';
+
+#content .item-content--coupon.sticky .coupon__row {
+  background-color: $color-pink;
+  padding: $grid-unit-2;
+
+  @media (max-width: $screen-xs-max) {
+    padding: $grid-unit-2 $grid-unit-2 $grid-unit-4 $grid-unit-2;
+  }
+
+  &:after {
+    @include text-label($label-size-small);
+    content: 'Top-Deal';
+    text-transform: uppercase;
+    position: absolute;
+    right: 1px;
+    bottom: 1px;
+    padding: $grid-unit-half $grid-unit-2;
+    background-color: $white;
+  }
+}
 
 .item-content--coupon {
+  position: relative;
+
+  .coupon__products-affiliate-links {
+    text-shadow: none;
+  }
   .coupon__title {
     @include text-helper($coupon__title-font-id, $coupon__title-size-mobile);
     letter-spacing: $coupon__title-letter-spacing;
@@ -267,7 +292,7 @@
     width: 100%;
 
     @media (min-width: $screen-md-min) {
-      @include vendor("flex-basis", 50%);
+      @include vendor('flex-basis', 50%);
       margin-left: $grid-unit-2;
     }
 

--- a/sass/variables/_variables.coupon.scss
+++ b/sass/variables/_variables.coupon.scss
@@ -1,3 +1,5 @@
+$coupon__top-deal--bg-color: $color-gray-5 !default;
+
 $coupon__row-border: $h-line-style !default;
 
 $coupon__title-font-id: $font-headline-id !default;

--- a/templates/node/coupon/node--coupon--content-reference.html.twig
+++ b/templates/node/coupon/node--coupon--content-reference.html.twig
@@ -3,6 +3,7 @@
   'item-content--coupon',
   'item-content--coupon--content_reference',
   'item-content--coupon--' ~ view_mode,
+  node.isSticky() ? 'sticky',
 ] %}
 
 {{ attach_library('infinite/coupons') }}

--- a/templates/node/coupon/node--coupon.html.twig
+++ b/templates/node/coupon/node--coupon.html.twig
@@ -73,10 +73,13 @@
  */
 #}
 
-{% set classes = [
-'item-content',
-'item-content--coupon',
-] %}  
+{%
+  set classes = [
+    'item-content',
+    'item-content--coupon',
+    node.isSticky() ? 'sticky',
+  ]
+%}
 
 <article{{ attributes.addClass(classes) }}>
     <div class="coupon__row">
@@ -112,7 +115,7 @@
           <span class="coupon__products-title">Top-Produkte</span>
           <a class="coupon__products-affiliate-links" href="/affiliatelinks" rel="nofollow" target="_self">Affiliatelinks</a>
         </div>
-        <div class="coupon__products">           
+        <div class="coupon__products">
             {{ content.field_advertising_products }}
         </div>
       </div>


### PR DESCRIPTION
## [INREL-4927](Ticket-URL) 
Coupons could be set to sticky via promotion option and are styled as 'Top Deals' in coupon views. 

## How to test:
Try on https://dev.instyle.de/black-shopping-friday-deals with some of the displayed coupon nodes.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [x] I have documented the changes (where applicable)
