### PR TITLE
INREL-6863 remove img-container ratio class - only 1 ratio container …

### DIFF
--- a/sass/mixins/_mixins.products.scss
+++ b/sass/mixins/_mixins.products.scss
@@ -318,7 +318,6 @@
     border-radius: $product-border-radius--single-product;
   }
 
-  .img-container,
   .media--blazy {
     position: relative;
     height: 0;


### PR DESCRIPTION
…needed

## [INREL-6863](https://jira.burda.com/browse/INREL-6863) 
The css ratio is on 2 classes applied.
`.item-product--single .img-container, .item-product--single .media--blazy`
apply either / or - not on both

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
