### PR TITLE
INREL-7168: feat: implements `$product__item-text-headline-height-mobile--ecommerce-slider-amp`

### DIFF
--- a/sass/variables/_variables.products.scss
+++ b/sass/variables/_variables.products.scss
@@ -33,6 +33,8 @@ $product__item-text-headline-height-mobile: 39px !default;
 $product__item-text-headline-height-tablet: 41px !default;
 $product__item-text-headline-height-desktop: 41px !default;
 
+$product__item-text-headline-height-mobile--ecommerce-slider-amp: unset !default;
+
 $product__item-text-headline-gap-bottom-mobile: 33px !default;
 $product__item-text-headline-gap-bottom-tablet: 33px !default;
 $product__item-text-headline-gap-bottom-desktop: 33px !default;


### PR DESCRIPTION
## [INREL-7168](https://jira.burda.com/browse/INREL-7168) 
 - Implements variable `$product__item-text-headline-height-mobile--ecommerce-slider-amp`
 - Constrains number of lines of text for product title on mobile in ecommerce sliders

## How to test:
 - https://backend.esquire.local/entertainment/musik/test?amp
 - set mobile viewport
 - ensure product title text is constrained to two lines

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
